### PR TITLE
Fix bagit.txt tag

### DIFF
--- a/docs/bagging/index.md
+++ b/docs/bagging/index.md
@@ -61,7 +61,7 @@ The bag must have a bagit.txt file, with the following tags.
 Tag | Allowed values
 ----|----
 BagIt-Version | 0.97 or 1.0
-BagIt-Version | UTF-8
+Tag-File-Character-Encoding | UTF-8
 
 ### bag-info.txt file
 


### PR DESCRIPTION
According to the [BagIt 1.0 standard](https://datatracker.ietf.org/doc/html/rfc8493), the encoding tag name should be `Tag-File-Character-Encoding`.